### PR TITLE
Fix: Add react-dropzone dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "react-beautiful-dnd": "^13.1.1",
     "react-day-picker": "^8.10.1",
     "react-dom": "^18.3.1",
+    "react-dropzone": "^14.2.3",
     "react-hook-form": "^7.53.0",
     "react-pdf": "6.2.2",
     "react-resizable-panels": "^2.1.3",


### PR DESCRIPTION
Adds 'react-dropzone' to package.json dependencies to resolve build failure where the module could not be found. This is required by the UploadStep component in the new PDF Merge Wizard.